### PR TITLE
Setup a pdfNode stresser

### DIFF
--- a/doc/invoice_big.json
+++ b/doc/invoice_big.json
@@ -1,0 +1,1548 @@
+{
+  "token": "15bfebf975034d9c8279da56900a43dd",
+  "replyto": "http:\/\/www.google.com",
+  "filename": "test_invoice_big.pdf",
+  "contents": {
+    "system": "invoicexpress",
+    "pdf_template": "classic",
+    "html_template": "invoice",
+    "document_id": 1,
+    "data": {
+      "logo_img": "http:\/\/localhost:3000\/sample\/img\/rupeal_logo.png",
+      "account": {
+        "organization_name": "SWAT",
+        "address": "Avenida Duque D'avila",
+        "postal_code": "1000-123",
+        "city": "Lisboa",
+        "country": "Portugal",
+        "email": {
+          "label": "Email:",
+          "value": "info11@example.com"
+        },
+        "fiscal_id": {
+          "label": "Vat Number:",
+          "value": "504301160"
+        },
+        "phone": {
+          "label": "Phone:",
+          "value": "213456789"
+        },
+        "fax": {
+          "label": "Fax:",
+          "value": "213456798"
+        },
+        "website": {
+          "label": "Website:",
+          "value": "www.weareswat.com"
+        },
+        "capital_funds": {
+          "label": "Capital Funds:",
+          "value": "50000"
+        },
+        "conservatory": {
+          "label": "Conservatory:",
+          "value": "Lisboa"
+        }
+      },
+      "client": {
+        "name": "Luke Skywalker",
+        "address": "LX Factory",
+        "postal_code": "1030-555",
+        "city": "Lisboa",
+        "country": "Portugal"
+      },
+      "copies": {
+        "number": 1,
+        "original": "Original",
+        "duplicate": "Duplicate",
+        "triplicate": "Triplicate",
+        "quadriplicate": "Quadriplicate"
+      },
+      "title": "Invoice nº I2016/7359",
+      "details": {
+        "date": {
+          "label": "Date",
+          "value": "17/08/2016"
+        },
+        "due_date": {
+          "label": "Due",
+          "value": "17/08/2016"
+        },
+        "client_fiscal_id": {
+          "label": "Vat Number",
+          "value": "504301161"
+        },
+        "reference": {
+          "label": "P.O.",
+          "value": "12345"
+        }
+      },
+      "invoice_items": {
+        "labels": {
+          "name": "Item",
+          "description": "Description",
+          "price": "Price",
+          "quantity": "Qty",
+          "taxes": "VAT",
+          "discount": "Dsc.",
+          "subtotal": "Total"
+        },
+        "items": [
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          }
+        ]
+      },
+      "tax_items": {
+        "labels": {
+          "name": "Tax",
+          "incidence": "Incidence",
+          "amount": "Amount"
+        },
+        "taxes": [
+          {
+            "name": "IVA23",
+            "incidence": "15.00€",
+            "amount": "3.45€"
+          }
+        ]
+      },
+      "summary": {
+        "title": "Summary",
+        "sum": {
+          "label": "SUM",
+          "value": "15.00€"
+        },
+        "discount": {
+          "label": "Discount",
+          "value": "0.00€"
+        },
+        "retention": {
+          "label": "Retention",
+          "value": "0.00€"
+        },
+        "total_before_taxes": {
+          "label": "w/o VAT",
+          "value": "15.00€"
+        },
+        "total_with_taxes": {
+          "label": "VAT",
+          "value": "18.45€"
+        }
+      },
+      "totals": {
+        "total": {
+          "label": "Total",
+          "value": "18.45€"
+        },
+        "total_multicurrency": {
+          "label": "Total in USD",
+          "value": "20.45$"
+        },
+        "rate": {
+          "label": "Exchange Rate",
+          "value": "1.2"
+        }
+      },
+      "cancellation_reason": {
+        "label": "Cancel message",
+        "value": "Reason for cancellation"
+      },
+      "observations": {
+        "label": "Observations",
+        "value": "No need for observations."
+      },
+      "mb_data": {
+        "title": "Multibanco",
+        "entity": {
+          "label": "Entity",
+          "value": 10611
+        },
+        "reference": {
+          "label": "Reference",
+          "value": "520 000 749"
+        },
+        "amount": {
+          "label": "Value",
+          "value": "18.45€"
+        }
+      },
+      "bank_data": {
+        "title": "Banking Details",
+        "bank_data_1": {
+          "label": "IBAN",
+          "value": "0020000001223456600677"
+        },
+        "bank_data_2": {
+          "label": "NIB",
+          "value": "200000012234566006"
+        },
+        "bank_data_3": {
+          "label": "SWIFT/BIC",
+          "value": "12000000122345660061111"
+        }
+      },
+      "footer": {
+        "document_footer": "Computer processed by InvoiceXpress - Certified program nº 192",
+        "custom_footer": "Powered by SWAT",
+        "iva_caixa": "IVA - regime de caixa"
+      }
+    }
+  }
+}

--- a/doc/invoice_medium.json
+++ b/doc/invoice_medium.json
@@ -1,0 +1,1098 @@
+{
+  "token": "15bfebf975034d9c8279da56900a43dd",
+  "replyto": "http:\/\/www.google.com",
+  "filename": "test_invoice_medium.pdf",
+  "contents": {
+    "system": "invoicexpress",
+    "pdf_template": "classic",
+    "html_template": "invoice",
+    "document_id": 1,
+    "data": {
+      "logo_img": "http:\/\/localhost:3000\/sample\/img\/rupeal_logo.png",
+      "account": {
+        "organization_name": "SWAT",
+        "address": "Avenida Duque D'avila",
+        "postal_code": "1000-123",
+        "city": "Lisboa",
+        "country": "Portugal",
+        "email": {
+          "label": "Email:",
+          "value": "info11@example.com"
+        },
+        "fiscal_id": {
+          "label": "Vat Number:",
+          "value": "504301160"
+        },
+        "phone": {
+          "label": "Phone:",
+          "value": "213456789"
+        },
+        "fax": {
+          "label": "Fax:",
+          "value": "213456798"
+        },
+        "website": {
+          "label": "Website:",
+          "value": "www.weareswat.com"
+        },
+        "capital_funds": {
+          "label": "Capital Funds:",
+          "value": "50000"
+        },
+        "conservatory": {
+          "label": "Conservatory:",
+          "value": "Lisboa"
+        }
+      },
+      "client": {
+        "name": "Luke Skywalker",
+        "address": "LX Factory",
+        "postal_code": "1030-555",
+        "city": "Lisboa",
+        "country": "Portugal"
+      },
+      "copies": {
+        "number": 1,
+        "original": "Original",
+        "duplicate": "Duplicate",
+        "triplicate": "Triplicate",
+        "quadriplicate": "Quadriplicate"
+      },
+      "title": "Invoice nº I2016/7359",
+      "details": {
+        "date": {
+          "label": "Date",
+          "value": "17/08/2016"
+        },
+        "due_date": {
+          "label": "Due",
+          "value": "17/08/2016"
+        },
+        "client_fiscal_id": {
+          "label": "Vat Number",
+          "value": "504301161"
+        },
+        "reference": {
+          "label": "P.O.",
+          "value": "12345"
+        }
+      },
+      "invoice_items": {
+        "labels": {
+          "name": "Item",
+          "description": "Description",
+          "price": "Price",
+          "quantity": "Qty",
+          "taxes": "VAT",
+          "discount": "Dsc.",
+          "subtotal": "Total"
+        },
+        "items": [
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          }
+        ]
+      },
+      "tax_items": {
+        "labels": {
+          "name": "Tax",
+          "incidence": "Incidence",
+          "amount": "Amount"
+        },
+        "taxes": [
+          {
+            "name": "IVA23",
+            "incidence": "15.00€",
+            "amount": "3.45€"
+          }
+        ]
+      },
+      "summary": {
+        "title": "Summary",
+        "sum": {
+          "label": "SUM",
+          "value": "15.00€"
+        },
+        "discount": {
+          "label": "Discount",
+          "value": "0.00€"
+        },
+        "retention": {
+          "label": "Retention",
+          "value": "0.00€"
+        },
+        "total_before_taxes": {
+          "label": "w/o VAT",
+          "value": "15.00€"
+        },
+        "total_with_taxes": {
+          "label": "VAT",
+          "value": "18.45€"
+        }
+      },
+      "totals": {
+        "total": {
+          "label": "Total",
+          "value": "18.45€"
+        },
+        "total_multicurrency": {
+          "label": "Total in USD",
+          "value": "20.45$"
+        },
+        "rate": {
+          "label": "Exchange Rate",
+          "value": "1.2"
+        }
+      },
+      "cancellation_reason": {
+        "label": "Cancel message",
+        "value": "Reason for cancellation"
+      },
+      "observations": {
+        "label": "Observations",
+        "value": "No need for observations."
+      },
+      "mb_data": {
+        "title": "Multibanco",
+        "entity": {
+          "label": "Entity",
+          "value": 10611
+        },
+        "reference": {
+          "label": "Reference",
+          "value": "520 000 749"
+        },
+        "amount": {
+          "label": "Value",
+          "value": "18.45€"
+        }
+      },
+      "bank_data": {
+        "title": "Banking Details",
+        "bank_data_1": {
+          "label": "IBAN",
+          "value": "0020000001223456600677"
+        },
+        "bank_data_2": {
+          "label": "NIB",
+          "value": "200000012234566006"
+        },
+        "bank_data_3": {
+          "label": "SWIFT/BIC",
+          "value": "12000000122345660061111"
+        }
+      },
+      "footer": {
+        "document_footer": "Computer processed by InvoiceXpress - Certified program nº 192",
+        "custom_footer": "Powered by SWAT",
+        "iva_caixa": "IVA - regime de caixa"
+      }
+    }
+  }
+}

--- a/doc/invoice_small.json
+++ b/doc/invoice_small.json
@@ -1,0 +1,639 @@
+{
+  "token": "15bfebf975034d9c8279da56900a43dd",
+  "replyto": "http:\/\/www.google.com",
+  "filename": "test_invoice_small.pdf",
+  "contents": {
+    "system": "invoicexpress",
+    "pdf_template": "classic",
+    "html_template": "invoice",
+    "document_id": 1,
+    "data": {
+      "logo_img": "http:\/\/localhost:3000\/sample\/img\/rupeal_logo.png",
+      "account": {
+        "organization_name": "SWAT",
+        "address": "Avenida Duque D'avila",
+        "postal_code": "1000-123",
+        "city": "Lisboa",
+        "country": "Portugal",
+        "email": {
+          "label": "Email:",
+          "value": "info11@example.com"
+        },
+        "fiscal_id": {
+          "label": "Vat Number:",
+          "value": "504301160"
+        },
+        "phone": {
+          "label": "Phone:",
+          "value": "213456789"
+        },
+        "fax": {
+          "label": "Fax:",
+          "value": "213456798"
+        },
+        "website": {
+          "label": "Website:",
+          "value": "www.weareswat.com"
+        },
+        "capital_funds": {
+          "label": "Capital Funds:",
+          "value": "50000"
+        },
+        "conservatory": {
+          "label": "Conservatory:",
+          "value": "Lisboa"
+        }
+      },
+      "client": {
+        "name": "Luke Skywalker",
+        "address": "LX Factory",
+        "postal_code": "1030-555",
+        "city": "Lisboa",
+        "country": "Portugal"
+      },
+      "copies": {
+        "number": 1,
+        "original": "Original",
+        "duplicate": "Duplicate",
+        "triplicate": "Triplicate",
+        "quadriplicate": "Quadriplicate"
+      },
+      "title": "Invoice nº I2016/7359",
+      "details": {
+        "date": {
+          "label": "Date",
+          "value": "17/08/2016"
+        },
+        "due_date": {
+          "label": "Due",
+          "value": "17/08/2016"
+        },
+        "client_fiscal_id": {
+          "label": "Vat Number",
+          "value": "504301161"
+        },
+        "reference": {
+          "label": "P.O.",
+          "value": "12345"
+        }
+      },
+      "invoice_items": {
+        "labels": {
+          "name": "Item",
+          "description": "Description",
+          "price": "Price",
+          "quantity": "Qty",
+          "taxes": "VAT",
+          "discount": "Dsc.",
+          "subtotal": "Total"
+        },
+        "items": [
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          },
+          {
+            "name": "iPhone",
+            "description": "iPhone 7",
+            "unit_price": "799.0000€",
+            "quantity": 1.0,
+            "tax_value": "23.00",
+            "discount": "0.0",
+            "subtotal": "799.0000€"
+          }
+        ]
+      },
+      "tax_items": {
+        "labels": {
+          "name": "Tax",
+          "incidence": "Incidence",
+          "amount": "Amount"
+        },
+        "taxes": [
+          {
+            "name": "IVA23",
+            "incidence": "15.00€",
+            "amount": "3.45€"
+          }
+        ]
+      },
+      "summary": {
+        "title": "Summary",
+        "sum": {
+          "label": "SUM",
+          "value": "15.00€"
+        },
+        "discount": {
+          "label": "Discount",
+          "value": "0.00€"
+        },
+        "retention": {
+          "label": "Retention",
+          "value": "0.00€"
+        },
+        "total_before_taxes": {
+          "label": "w/o VAT",
+          "value": "15.00€"
+        },
+        "total_with_taxes": {
+          "label": "VAT",
+          "value": "18.45€"
+        }
+      },
+      "totals": {
+        "total": {
+          "label": "Total",
+          "value": "18.45€"
+        },
+        "total_multicurrency": {
+          "label": "Total in USD",
+          "value": "20.45$"
+        },
+        "rate": {
+          "label": "Exchange Rate",
+          "value": "1.2"
+        }
+      },
+      "cancellation_reason": {
+        "label": "Cancel message",
+        "value": "Reason for cancellation"
+      },
+      "observations": {
+        "label": "Observations",
+        "value": "No need for observations."
+      },
+      "mb_data": {
+        "title": "Multibanco",
+        "entity": {
+          "label": "Entity",
+          "value": 10611
+        },
+        "reference": {
+          "label": "Reference",
+          "value": "520 000 749"
+        },
+        "amount": {
+          "label": "Value",
+          "value": "18.45€"
+        }
+      },
+      "bank_data": {
+        "title": "Banking Details",
+        "bank_data_1": {
+          "label": "IBAN",
+          "value": "0020000001223456600677"
+        },
+        "bank_data_2": {
+          "label": "NIB",
+          "value": "200000012234566006"
+        },
+        "bank_data_3": {
+          "label": "SWIFT/BIC",
+          "value": "12000000122345660061111"
+        }
+      },
+      "footer": {
+        "document_footer": "Computer processed by InvoiceXpress - Certified program nº 192",
+        "custom_footer": "Powered by SWAT",
+        "iva_caixa": "IVA - regime de caixa"
+      }
+    }
+  }
+}

--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,12 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :aliases {"stress-sequences" ["run"]
-            "stress-pdfs" ["run" "-m" "ix-stresser.pdf/-main"]}
+            "stress-pdfs" ["run" "-m" "ix-stresser.pdf/-main"]
+            "stress-pdfNode" ["run" "-m" "ix-stresser.pdfnode/-main"]}
   :main ix-stresser.core
   :dependencies [[org.clojure/clojure "1.9.0-alpha10"]
                  [org.clojure/core.async "0.2.385"]
-                 [invoice-spec "1.3.0"]]
+                 [org.clojure/data.json "0.2.6"]
+                 [invoice-spec "1.3.0"]
+                 [clj-http "3.2.0"]]
   :plugins [[lein-environ "1.0.3"]])

--- a/src/ix_stresser/pdfnode.clj
+++ b/src/ix_stresser/pdfnode.clj
@@ -1,0 +1,60 @@
+(ns ix-stresser.pdfnode
+  (:require [clj-http.client :as client]
+            [clojure.core.async :as async :refer [<! <!! go go-loop timeout]]
+            [clojure.data.json :as json]))
+
+(def base-files-path "./doc/")
+(def dev-url "http://localhost:3000")
+(def stag-url "http://pdfnode-staging.cloudapp.net")
+(def prod-url "http://pdfnode.cloudapp.net")
+(def existing-files ["invoice_small.json", "invoice_medium.json", "invoice_big.json"])
+(def existing-files-data {})
+(def stressing-times 50)
+(def requesting-times 5)
+
+(defn url-for [url, endpoint]
+  (str url endpoint))
+
+(defn read-file [filename]
+  (slurp (str base-files-path filename)))
+
+;; (defn read-all-files 
+;;  (doseq [filename existing-files]
+;;    (assoc existing-files-data (keyword filename) (read-file filename))))
+
+(defn do-request [endpoint, filename]
+  (let [data (read-file filename)]
+    (println ".Calling" endpoint)
+    (client/post endpoint { :content-type :json
+                            :body data
+                            :socket-timeout 1000
+                            :conn-timeout 1000
+                            :accept :json })))
+
+(defn print-response [request-ch]
+  (go
+    (let [response request-ch]
+      (println ".Response" response))))
+
+(defn stress-out [url, endpoint]
+  (doseq [filename existing-files]
+    (dotimes [n requesting-times]
+      (future (do-request (url-for url endpoint) filename )))))
+
+(defn start-stressing [urls endpoint]
+  (dotimes [n stressing-times]
+    (doseq [url urls]
+      (stress-out url endpoint)
+      (prn "--- sleep 1s" )
+      (<!! (timeout 1000)))))
+
+(defn runner [args]
+  (let [endpoint (or (first args) "/pdf/applyTemplate")]
+    ;; (<!! (start-stressing [dev-url] endpoint)) ;; stressing localy
+    ;; (<!! (start-stressing [stag-url] endpoint)) ;; stressing staging
+    ;; (<!! (start-stressing [prod-url] endpoint)) ;; stressing production
+    (start-stressing [stag-url, prod-url] endpoint) ;; stressing multiple envs
+    (prn "OK!")))
+
+(defn -main [& args]
+  (runner args))


### PR DESCRIPTION
**Motivation:**
Having the new pdfNode production/staging machines up and running we
want a way (wihtout using the malaca's stressing machine) to call these
pdfNodes and load test them.

**Modifications:**
We neede the documents data examples to generate the pdfs. On the docs
folder were created one invoice small (having +50 items), a medium one
(having +100 items) and a big one (with +150 items).
The project.clj was updated about some libraries needed and the
stresser was created on the ix_stresser folder and called: pdfnode.clj.

**Result:**
From now one, to load stress pdfNode about the generation of pdfs, we
will not need the malaca's stressing machine and we make Marcos proud.
We have a SCRIPT! :D
