### PR TITLE
Create pdfNode bulk stresser

### DIFF
--- a/doc/invoice_big.json
+++ b/doc/invoice_big.json
@@ -1,5 +1,5 @@
 {
-  "token": "15bfebf975034d9c8279da56900a43dd",
+  "token": "",
   "replyto": "http:\/\/www.google.com",
   "filename": "test_invoice_big.pdf",
   "contents": {

--- a/doc/invoice_medium.json
+++ b/doc/invoice_medium.json
@@ -1,5 +1,5 @@
 {
-  "token": "15bfebf975034d9c8279da56900a43dd",
+  "token": "",
   "replyto": "http:\/\/www.google.com",
   "filename": "test_invoice_medium.pdf",
   "contents": {

--- a/doc/invoice_small.json
+++ b/doc/invoice_small.json
@@ -1,5 +1,5 @@
 {
-  "token": "15bfebf975034d9c8279da56900a43dd",
+  "token": "",
   "replyto": "http:\/\/www.google.com",
   "filename": "test_invoice_small.pdf",
   "contents": {

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :aliases {"stress-sequences" ["run"]
             "stress-basic-requests" ["run" "-m" "ix-stresser.basic-requests/-main"]
             "stress-pdfs" ["run" "-m" "ix-stresser.pdf/-main"]
-            "stress-pdfNode" ["run" "-m" "ix-stresser.pdfnode/-main"]}
+            "stress-pdfnode" ["run" "-m" "ix-stresser.pdfnode/-main"]
+            "stress-pdfbulknode" ["run" "-m" "ix-stresser.pdfbulknode/-main"]}
   :main ix-stresser.core
   :dependencies [[org.clojure/clojure "1.9.0-alpha10"]
                  [org.clojure/core.async "0.2.385"]

--- a/src/ix_stresser/pdfbulknode.clj
+++ b/src/ix_stresser/pdfbulknode.clj
@@ -1,0 +1,87 @@
+(ns ix-stresser.pdfbulknode
+  (:require [clj-http.client :as client]
+            [clojure.core.async :as async :refer [<! <!! go go-loop timeout]]
+            [clojure.data.json :as json]))
+
+(def base-files-path "./doc/")
+(def dev-url "http://localhost:3000")
+(def stag-url "http://pdfnode-staging.cloudapp.net")
+(def prod-url "http://pdfnode.cloudapp.net")
+(def existing-files ["invoice_small.json", "invoice_medium.json", "invoice_big.json"])
+
+(def document-multiplier 1) ;; 1 will mean a single bulk having 3 invoices, small, medium and big
+;; 2 will mean 6 invoices, 2 small, 2 medium , 2 big... and so on...
+
+(def stressing-times 1)
+(def requesting-times 1)
+
+(defn url-for [url, endpoint]
+  (str url endpoint))
+
+(defn read-file [filename]
+  (json/read-str (slurp (str base-files-path filename)) :key-fn keyword))
+
+(defn read-all-files []
+  (reduce (fn [hash filename]
+            (assoc hash (keyword filename) (read-file filename)))
+          {}
+          existing-files))
+
+(defn bulk-contents-data []
+  (reduce (fn [array filename]
+            (->> (read-all-files)
+                 ((keyword filename))
+                 (conj array)
+             ))
+          []
+          existing-files))
+
+(defn bulk-data []
+  { :token "15bfebf975034d9c8279da56900a43dd",
+    :replyto "http://ricardofiel.com",
+    :filename "my_bulk_test.zip",
+    :contents (->> (bulk-contents-data)
+                   (repeat)
+                   (take document-multiplier)
+                   (flatten)
+                   (map-indexed (fn [idx file-data]
+                      (assoc file-data :filename (str idx ".pdf")))))})
+
+(defn do-request [endpoint data]
+  (println ".Calling " endpoint)
+  (client/post endpoint { :content-type :json
+                          :body (json/write-str data)
+                          :socket-timeout 1000
+                          :conn-timeout 1000
+                          :accept :json }))
+
+(defn print-response [request-ch]
+  (go
+    (let [response request-ch]
+      (println ".Response" response))))
+
+(defn stress-out [url endpoint bulk-data]
+  (dotimes [n requesting-times]
+    (future 
+      (try
+        (do-request (url-for url endpoint) bulk-data )
+        (catch Exception e
+          (prn e))))))
+
+(defn start-stressing [urls endpoint bulk-data]
+  (dotimes [n stressing-times]
+    (doseq [url urls]
+      (stress-out url endpoint bulk-data)
+      (prn "--- sleep 1s" )
+      (<!! (timeout 1000)))))
+
+(defn runner [args]
+  (let [endpoint (or (first args) "/pdf/applyTemplateBulk")]
+    (start-stressing [dev-url] endpoint (bulk-data)) ;; stressing localy
+    ;; (start-stressing [stag-url] endpoint (bulk-data)) ;; stressing staging
+    ;; (start-stressing [prod-url] endpoint (bulk-data)) ;; stressing production
+    ;; (start-stressing [stag-url, prod-url] endpoint (bulk-data)) ;; stressing multiple envs
+    (prn "OK!")))
+
+(defn -main [& args]
+  (runner args))

--- a/src/ix_stresser/pdfbulknode.clj
+++ b/src/ix_stresser/pdfbulknode.clj
@@ -1,12 +1,13 @@
 (ns ix-stresser.pdfbulknode
-  (:require [clj-http.client :as client]
+  (:require [environ.core :refer [env]]
+            [clj-http.client :as client]
             [clojure.core.async :as async :refer [<! <!! go go-loop timeout]]
             [clojure.data.json :as json]))
 
 (def base-files-path "./doc/")
 (def dev-url "http://localhost:3000")
-(def stag-url "http://pdfnode-staging.cloudapp.net")
-(def prod-url "http://pdfnode.cloudapp.net")
+(def stag-url (env :pdfnode-stag-url))
+(def prod-url (env :pdfnode-prod-url))
 (def existing-files ["invoice_small.json", "invoice_medium.json", "invoice_big.json"])
 
 (def document-multiplier 1) ;; 1 will mean a single bulk having 3 invoices, small, medium and big
@@ -45,7 +46,7 @@
                       (assoc file-data :filename (str file-counter ".pdf"))))))
 
 (defn bulk-data []
-  { :token "15bfebf975034d9c8279da56900a43dd",
+  { :token (env :pdfnode-token),
     :replyto "http://ricardofiel.com",
     :filename "my_bulk_test",
     :contents (setup-bulk-contents)})
@@ -85,10 +86,10 @@
 
 (defn runner [args]
   (let [endpoint (or (first args) "/pdf/applyTemplateBulk")]
-    (start-stressing [dev-url] endpoint (bulk-data)) ;; stressing localy
+    ;; (start-stressing [dev-url] endpoint (bulk-data)) ;; stressing localy
     ;; (start-stressing [stag-url] endpoint (bulk-data)) ;; stressing staging
     ;; (start-stressing [prod-url] endpoint (bulk-data)) ;; stressing production
-    ;; (start-stressing [stag-url, prod-url] endpoint (bulk-data)) ;; stressing multiple envs
+    (start-stressing [dev-url, stag-url, prod-url] endpoint (bulk-data)) ;; stressing multiple envs
     (prn "OK!")))
 
 (defn -main [& args]

--- a/src/ix_stresser/pdfnode.clj
+++ b/src/ix_stresser/pdfnode.clj
@@ -50,10 +50,10 @@
 
 (defn runner [args]
   (let [endpoint (or (first args) "/pdf/applyTemplate")]
-    ;; (start-stressing [dev-url] endpoint (read-all-files)) ;; stressing localy
+    (start-stressing [dev-url] endpoint (read-all-files)) ;; stressing localy
     ;; (start-stressing [stag-url] endpoint (read-all-files)) ;; stressing staging
     ;; (start-stressing [prod-url] endpoint (read-all-files)) ;; stressing production
-    (start-stressing [stag-url, prod-url] endpoint (read-all-files)) ;; stressing multiple envs
+    ;; (start-stressing [stag-url, prod-url] endpoint (read-all-files)) ;; stressing multiple envs
     (prn "OK!")))
 
 (defn -main [& args]


### PR DESCRIPTION
**Motivation:**
Just has we want to stress pdf generators endpoints of pdfNode, we want
too to stress the endpoints about bulks. We want and need to test all
these endpoints and check pdfNode reaction on big loads.

**Modifications:**
A new file was created, pdfbulknode.clj. This one, just like
pdfnode.clj, has the code and the request by default the
`applyTemplateBulk` endpoint but we can pass as parameter the endpoint
we want to stress out.

**Result:**
The stresser is looking good. Some tests were made and pdfNode responde
as expected so let the games begin and try to break pdfNode :P
